### PR TITLE
Fix: Allow TypeScript imports without .js extension

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   /// <reference path="../../../types/global.d.ts" />
-  import { WebRTCApp } from './lib/webrtc/WebRTCApp.js';
+  import { WebRTCApp } from './lib/webrtc/WebRTCApp';
   import MainAppRouter from './components/MainAppRouter.svelte';
   import AuthHandler from './components/AuthHandler.svelte';
   import ProfileSetup from './components/ProfileSetup.svelte'; // Import the new component
-  import { authStore, type AuthState } from './stores/authStore.js';
-  import { profileStore, type ProfileState } from './stores/profileStore.js'; // Import profile store
+  import { authStore, type AuthState } from './stores/authStore';
+  import { profileStore, type ProfileState } from './stores/profileStore'; // Import profile store
   import { onDestroy } from 'svelte';
 
   const webRTCApp = new WebRTCApp();

--- a/src/components/ActivityFeed.svelte
+++ b/src/components/ActivityFeed.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import type { FileTransfer } from '../lib/fileBridge.js';
-  import type { TranscriptionSegment } from '../lib/media/transcriber.js';
+  import type { FileTransfer } from '../lib/fileBridge';
+  import type { TranscriptionSegment } from '../lib/media/transcriber';
   import type { CarouselMediaItem } from './MediaCarousel.svelte';
 
   // --- Types for Combined Feed Item (Prop) ---

--- a/src/components/AuthHandler.svelte
+++ b/src/components/AuthHandler.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { authStore, type AuthState } from '../stores/authStore.js';
-  import { getConfigValue } from '../stores/configStore.js';
+  import { authStore, type AuthState } from '../stores/authStore';
+  import { getConfigValue } from '../stores/configStore';
   import ConfigOverlay from './ConfigOverlay.svelte';
 
   let showConfigOverlay = $state(false);

--- a/src/components/ConfigOverlay.svelte
+++ b/src/components/ConfigOverlay.svelte
@@ -6,7 +6,7 @@
     type GeneralConfig,
     type RtcConfig,
     type MediaConfig
-  } from '../stores/configStore.js';
+  } from '../stores/configStore';
   import { onMount } from 'svelte'; // onMount is not strictly needed if using $effect for this
 
   // Props

--- a/src/components/ContextMenu.svelte
+++ b/src/components/ContextMenu.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import type { MenuItem } from '../types/menu.js';
+  import type { MenuItem } from '../types/menu';
 
   // Props
   let {

--- a/src/components/ControlPanel.svelte
+++ b/src/components/ControlPanel.svelte
@@ -5,10 +5,7 @@
   import { profileStore } from '../stores/profileStore';
   import { chatStore } from '../lib/chatBridge';
   import { fileStore, type FileTransfer } from '../lib/fileBridge';
-  import {
-    transcriptionDisplayStore,
-    type TranscriptionSegment
-  } from '../lib/media/transcriber';
+  import { transcriptionDisplayStore, type TranscriptionSegment } from '../lib/media/transcriber';
   import MediaCarousel, { type CarouselMediaItem } from './MediaCarousel.svelte';
 
   import ParticipantsPanel from './ParticipantsPanel.svelte';

--- a/src/components/ControlPanel.svelte
+++ b/src/components/ControlPanel.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
   import { tick } from 'svelte';
-  import { getKeysByCid } from '../stores/cidKeyStore.js';
-  import { getPeerProfile } from '../stores/peerProfileStore.js';
-  import { profileStore } from '../stores/profileStore.js';
-  import { chatStore } from '../lib/chatBridge.js';
-  import { fileStore, type FileTransfer } from '../lib/fileBridge.js';
+  import { getKeysByCid } from '../stores/cidKeyStore';
+  import { getPeerProfile } from '../stores/peerProfileStore';
+  import { profileStore } from '../stores/profileStore';
+  import { chatStore } from '../lib/chatBridge';
+  import { fileStore, type FileTransfer } from '../lib/fileBridge';
   import {
     transcriptionDisplayStore,
     type TranscriptionSegment
-  } from '../lib/media/transcriber.js';
+  } from '../lib/media/transcriber';
   import MediaCarousel, { type CarouselMediaItem } from './MediaCarousel.svelte';
 
   import ParticipantsPanel from './ParticipantsPanel.svelte';

--- a/src/components/ControlPanel.test.ts
+++ b/src/components/ControlPanel.test.ts
@@ -10,8 +10,8 @@ import type { CidKeys } from '../stores/cidKeyStore';
 import type { PeerProfile } from '../stores/peerProfileStore';
 
 // Import the functions we are mocking to get a reference to the mocked versions
-import { getKeysByCid } from '../stores/cidKeyStore.js';
-import { getPeerProfile } from '../stores/peerProfileStore.js';
+import { getKeysByCid } from '../stores/cidKeyStore';
+import { getPeerProfile } from '../stores/peerProfileStore';
 
 // Mock stores and functions (these mocks apply to the imports above too)
 vi.mock('../stores/cidKeyStore.js', () => ({

--- a/src/components/ForwardOverlay.svelte
+++ b/src/components/ForwardOverlay.svelte
@@ -5,7 +5,7 @@
     setForwardPeer,
     toggleForwardHandler,
     type LogMessage
-  } from '../lib/forwardBridge.js';
+  } from '../lib/forwardBridge';
   import DraggableOverlayBase from './DraggableOverlayBase.svelte';
 
   const show = $derived(!!$forwardStore.allowedHosts.length || !!$forwardStore.forwardHost);

--- a/src/components/InputArea.svelte
+++ b/src/components/InputArea.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { tick } from 'svelte';
-  import { sendChatMessage } from '../lib/chatBridge.js';
-  import { sendFile, type FileTransfer } from '../lib/fileBridge.js'; // type FileTransfer might not be needed if not used directly
-  import { transcriberStore, transcriptionDisplayStore } from '../lib/media/transcriber.js';
-  import { profileStore } from '../stores/profileStore.js';
+  import { sendChatMessage } from '../lib/chatBridge';
+  import { sendFile, type FileTransfer } from '../lib/fileBridge'; // type FileTransfer might not be needed if not used directly
+  import { transcriberStore, transcriptionDisplayStore } from '../lib/media/transcriber';
+  import { profileStore } from '../stores/profileStore';
 
   // --- Types for Staged Files ---
   // Moved from ControlPanel.svelte

--- a/src/components/LayoutControls.svelte
+++ b/src/components/LayoutControls.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { LayoutType } from '../stores/streamStore.js';
+  import type { LayoutType } from '../stores/streamStore';
 
   let {
     currentLayout,

--- a/src/components/MainAppRouter.svelte
+++ b/src/components/MainAppRouter.svelte
@@ -1,20 +1,20 @@
 <script lang="ts">
   /// <reference path="../../../../types/global.d.ts" />
   import { onMount, onDestroy } from 'svelte';
-  // import { authStore, type AuthState } from '../stores/authStore.js'; // No longer directly needed for UI
+  // import { authStore, type AuthState } from '../stores/authStore'; // No longer directly needed for UI
   import MediaArea from './MediaArea.svelte';
   import ControlPanel from './ControlPanel.svelte';
   import CopyOverlay from './CopyOverlay.svelte';
   import ConfigOverlay from './ConfigOverlay.svelte';
   import ForwardOverlay from './ForwardOverlay.svelte';
-  import { configStore, getAllConfig, type Config } from '../stores/configStore.js';
-  import { connectionStore, getDirectClient } from '../stores/connectionStore.js';
-  import { compress, decompress } from '../lib/utils/sdpCompress.js';
-  import type { WebRTCApp } from '../lib/webrtc/WebRTCApp.js';
+  import { configStore, getAllConfig, type Config } from '../stores/configStore';
+  import { connectionStore, getDirectClient } from '../stores/connectionStore';
+  import { compress, decompress } from '../lib/utils/sdpCompress';
+  import type { WebRTCApp } from '../lib/webrtc/WebRTCApp';
 
-  import type { AppLogic, AppLogicContext, AppLogicState } from '../lib/appLogic.js';
-  import { ClientLogic } from '../lib/clientLogic.js';
-  import { ServerLogic } from '../lib/serverLogic.js';
+  import type { AppLogic, AppLogicContext, AppLogicState } from '../lib/appLogic';
+  import { ClientLogic } from '../lib/clientLogic';
+  import { ServerLogic } from '../lib/serverLogic';
 
   // Props
   export let webRTCApp: WebRTCApp;

--- a/src/components/MediaArea.svelte
+++ b/src/components/MediaArea.svelte
@@ -7,27 +7,27 @@
     updateLocalStreamProperties,
     getLocalStreamsByType,
     type LayoutType
-  } from '../stores/streamStore.js';
+  } from '../stores/streamStore';
   import {
     normalizeStreamId,
     setupLocalFileStream,
     setAudioCallback
-  } from '../lib/streamBridge.js';
+  } from '../lib/streamBridge';
   import {
     forwardStore,
     toggleForwardHandler as actualToggleForwardHandler
-  } from '../lib/forwardBridge.js';
-  import { recorderStore, toggleRecording } from '../lib/media/recorder.js';
+  } from '../lib/forwardBridge';
+  import { recorderStore, toggleRecording } from '../lib/media/recorder';
   import {
     transcriberStore,
     toggleOverallTranscription,
     stopOverallTranscription
-  } from '../lib/media/transcriber.js';
-  import { calculateStreamPositions } from '../lib/media/streamLayout.js';
+  } from '../lib/media/transcriber';
+  import { calculateStreamPositions } from '../lib/media/streamLayout';
   import ContextMenu from './ContextMenu.svelte';
-  import { updateConfig, configStore } from '../stores/configStore.js';
-  import type { MenuItem } from '../types/menu.js';
-  import { addLocalFileStream, removeLocalFileStream } from '../stores/localFileStreamStore.js';
+  import { updateConfig, configStore } from '../stores/configStore';
+  import type { MenuItem } from '../types/menu';
+  import { addLocalFileStream, removeLocalFileStream } from '../stores/localFileStreamStore';
 
   import LayoutControls from './LayoutControls.svelte';
   import StreamDisplayArea from './StreamDisplayArea.svelte';
@@ -71,7 +71,7 @@
     )
   );
 
-  import type { ViewableStream } from '../types/viewableStream.js';
+  import type { ViewableStream } from '../types/viewableStream';
 
   const groupedStreams = $derived.by(() => {
     const groups: Record<

--- a/src/components/MediaArea.svelte
+++ b/src/components/MediaArea.svelte
@@ -8,11 +8,7 @@
     getLocalStreamsByType,
     type LayoutType
   } from '../stores/streamStore';
-  import {
-    normalizeStreamId,
-    setupLocalFileStream,
-    setAudioCallback
-  } from '../lib/streamBridge';
+  import { normalizeStreamId, setupLocalFileStream, setAudioCallback } from '../lib/streamBridge';
   import {
     forwardStore,
     toggleForwardHandler as actualToggleForwardHandler

--- a/src/components/MediaCarousel.svelte
+++ b/src/components/MediaCarousel.svelte
@@ -13,7 +13,7 @@
 
 <script lang="ts">
   import { onMount, onDestroy, tick } from 'svelte';
-  import type { FileTransfer } from '../lib/fileBridge.js';
+  import type { FileTransfer } from '../lib/fileBridge';
 
   type Props = {
     items?: CarouselMediaItem[];

--- a/src/components/MediaControls.svelte
+++ b/src/components/MediaControls.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { MenuItem } from '../types/menu.js';
+  import type { MenuItem } from '../types/menu';
 
   let {
     hangup,

--- a/src/components/ParticipantsPanel.svelte
+++ b/src/components/ParticipantsPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { connectionStore } from '../stores/connectionStore.js'; // getDirectClientState, getParticipantState are not directly used in template
-  import { getKeysByCid } from '../stores/cidKeyStore.js';
-  import { getPeerProfile } from '../stores/peerProfileStore.js';
+  import { connectionStore } from '../stores/connectionStore'; // getDirectClientState, getParticipantState are not directly used in template
+  import { getKeysByCid } from '../stores/cidKeyStore';
+  import { getPeerProfile } from '../stores/peerProfileStore';
 </script>
 
 <!-- Participants Panel -->

--- a/src/components/ProfileSetup.svelte
+++ b/src/components/ProfileSetup.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { profileStore, updateUserProfile } from '../stores/profileStore.js';
+  import { profileStore, updateUserProfile } from '../stores/profileStore';
 
   let userName = '';
 

--- a/src/components/StreamDisplayArea.svelte
+++ b/src/components/StreamDisplayArea.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import StreamView from './StreamView.svelte';
-  import type { ViewableStream } from '../types/viewableStream.js';
+  import type { ViewableStream } from '../types/viewableStream';
 
   let {
     activeStreams,

--- a/src/components/StreamView.svelte
+++ b/src/components/StreamView.svelte
@@ -34,8 +34,8 @@
     drawVisualization,
     type AudioNodes,
     normalizeStreamId
-  } from '../lib/media/stream.js';
-  import { setStreamMetadata } from '../stores/localFileStreamStore.js';
+  } from '../lib/media/stream';
+  import { setStreamMetadata } from '../stores/localFileStreamStore';
 
   let audioNodes: AudioNodes | null;
   let audioVisualizationCanvas: HTMLCanvasElement | undefined = $state();

--- a/src/lib/appLogic.ts
+++ b/src/lib/appLogic.ts
@@ -1,10 +1,7 @@
 import type { WebRTCApp } from './webrtc/WebRTCApp';
 import type { Config } from '../stores/configStore';
 import type { getDirectClient as getDirectClientType } from '../stores/connectionStore';
-import type {
-  compress as compressType,
-  decompress as decompressType
-} from './utils/sdpCompress';
+import type { compress as compressType, decompress as decompressType } from './utils/sdpCompress';
 
 export interface AppLogicState {
   showCopyOverlay: boolean;

--- a/src/lib/appLogic.ts
+++ b/src/lib/appLogic.ts
@@ -1,10 +1,10 @@
-import type { WebRTCApp } from './webrtc/WebRTCApp.js';
-import type { Config } from '../stores/configStore.js';
-import type { getDirectClient as getDirectClientType } from '../stores/connectionStore.js';
+import type { WebRTCApp } from './webrtc/WebRTCApp';
+import type { Config } from '../stores/configStore';
+import type { getDirectClient as getDirectClientType } from '../stores/connectionStore';
 import type {
   compress as compressType,
   decompress as decompressType
-} from './utils/sdpCompress.js';
+} from './utils/sdpCompress';
 
 export interface AppLogicState {
   showCopyOverlay: boolean;

--- a/src/lib/chatBridge.test.ts
+++ b/src/lib/chatBridge.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { get } from 'svelte/store';
-import * as chatBridgeModule from './chatBridge.js';
+import * as chatBridgeModule from './chatBridge';
 
 describe('chatBridge', () => {
   beforeEach(() => {

--- a/src/lib/chatBridge.ts
+++ b/src/lib/chatBridge.ts
@@ -1,5 +1,5 @@
 import { writable, get } from 'svelte/store';
-import { getDirectClient, getAllDirectClients } from '../stores/connectionStore.js'; // Adjust path if needed
+import { getDirectClient, getAllDirectClients } from '../stores/connectionStore'; // Adjust path if needed
 
 // Chat state interface
 export interface ChatState {

--- a/src/lib/clientLogic.test.ts
+++ b/src/lib/clientLogic.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { ClientLogic } from './clientLogic.js';
-import type { AppLogicContext, AppLogicState } from './appLogic.js';
-import type { Config } from '../stores/configStore.js';
+import { ClientLogic } from './clientLogic';
+import type { AppLogicContext, AppLogicState } from './appLogic';
+import type { Config } from '../stores/configStore';
 // REMOVED: import { defaultConfig } from '../stores/configStore';
 
 // Mock BroadcastChannel

--- a/src/lib/clientLogic.ts
+++ b/src/lib/clientLogic.ts
@@ -1,4 +1,4 @@
-import type { AppLogic, AppLogicContext, AppLogicState } from './appLogic.js';
+import type { AppLogic, AppLogicContext, AppLogicState } from './appLogic';
 /// <reference path="../../../types/global.d.ts" />
 // import { connectionStore } from '../stores/connectionStore'; // For direct $connectionStore access if needed
 

--- a/src/lib/fileBridge.ts
+++ b/src/lib/fileBridge.ts
@@ -3,7 +3,7 @@ import {
   getDirectClient,
   getAllClientCids,
   getAllDirectClients
-} from '../stores/connectionStore.js'; // Adjust path if needed
+} from '../stores/connectionStore'; // Adjust path if needed
 
 // File transfer state interface
 export interface FileTransfer {

--- a/src/lib/fileBridge.ts
+++ b/src/lib/fileBridge.ts
@@ -1,9 +1,5 @@
 import { writable, get } from 'svelte/store';
-import {
-  getDirectClient,
-  getAllClientCids,
-  getAllDirectClients
-} from '../stores/connectionStore'; // Adjust path if needed
+import { getDirectClient, getAllClientCids, getAllDirectClients } from '../stores/connectionStore'; // Adjust path if needed
 
 // File transfer state interface
 export interface FileTransfer {

--- a/src/lib/forwardBridge.ts
+++ b/src/lib/forwardBridge.ts
@@ -1,6 +1,6 @@
 import { writable, get } from 'svelte/store';
-import { getDirectClient, getAllDirectClients } from '../stores/connectionStore.js'; // Adjust path if needed
-import { registerCleanup } from '../stores/appStateStore.js'; // Import store function
+import { getDirectClient, getAllDirectClients } from '../stores/connectionStore'; // Adjust path if needed
+import { registerCleanup } from '../stores/appStateStore'; // Import store function
 
 // Forward state interface
 export interface LogMessage {
@@ -116,7 +116,7 @@ export function forwardInit(): void {
 }
 
 // Export utility functions from the original forward.ts
-import { sendData, concatUint8Arrays, setButton } from './webrtc/forward.js';
+import { sendData, concatUint8Arrays, setButton } from './webrtc/forward';
 
 export { concatUint8Arrays }; // Export for use in tests or other modules
 

--- a/src/lib/media/recorder.ts
+++ b/src/lib/media/recorder.ts
@@ -5,10 +5,10 @@ import {
   type DrawFunction
 } from 'video-stream-merger';
 import { writable, get } from 'svelte/store';
-import { normalizeStreamId } from './stream.js';
-import { getStreamState, type StreamState } from '../../stores/streamStore.js';
-import { calculateStreamLayout, calculateGridPositions, type Position } from './streamLayout.js';
-import { getStreamMetadata } from '../../stores/localFileStreamStore.js';
+import { normalizeStreamId } from './stream';
+import { getStreamState, type StreamState } from '../../stores/streamStore';
+import { calculateStreamLayout, calculateGridPositions, type Position } from './streamLayout';
+import { getStreamMetadata } from '../../stores/localFileStreamStore';
 
 // Constants
 const FW = 1920;

--- a/src/lib/media/stream.ts
+++ b/src/lib/media/stream.ts
@@ -1,7 +1,7 @@
 // Import types from global.d.ts
 /// <reference path="../../../types/global.d.ts" />
 
-import { getAllDirectClients } from '../../stores/connectionStore.js';
+import { getAllDirectClients } from '../../stores/connectionStore';
 // Use type assertion to handle vendor prefixes
 window.AudioContext = window.AudioContext || (window as any).webkitAudioContext;
 

--- a/src/lib/media/streamLayout.ts
+++ b/src/lib/media/streamLayout.ts
@@ -1,6 +1,6 @@
 import { get } from 'svelte/store';
-import { streamStore, type LayoutType } from '../../stores/streamStore.js';
-import { normalizeStreamId } from '../streamBridge.js';
+import { streamStore, type LayoutType } from '../../stores/streamStore';
+import { normalizeStreamId } from '../streamBridge';
 
 /**
  * Calculate optimal layout for streams in a container

--- a/src/lib/media/transcriber.ts
+++ b/src/lib/media/transcriber.ts
@@ -5,8 +5,8 @@ import {
   type LocalStreamData,
   type RemoteStreamData,
   type StreamState
-} from '../../stores/streamStore.js';
-import { getDirectClient, getAllDirectClients } from '../../stores/connectionStore.js'; // Added
+} from '../../stores/streamStore';
+import { getDirectClient, getAllDirectClients } from '../../stores/connectionStore'; // Added
 
 const WEBSOCKET_URL = 'ws://localhost:8888/asr'; // Ensure this matches your ASR backend
 const TRANSCRIPTION_CHUNK_DURATION_MS = 5000;

--- a/src/lib/serverLogic.ts
+++ b/src/lib/serverLogic.ts
@@ -1,4 +1,4 @@
-import type { AppLogic, AppLogicContext } from './appLogic.js';
+import type { AppLogic, AppLogicContext } from './appLogic';
 import { io, Socket } from 'socket.io-client';
 // RTCIceCandidateInit should be globally available or via WebRTC types.
 

--- a/src/lib/streamBridge.ts
+++ b/src/lib/streamBridge.ts
@@ -9,11 +9,7 @@ import {
   getLocalStreamsByType
 } from '../stores/streamStore';
 import { getAllConfig, configStore, type Config, type MediaConfig } from '../stores/configStore';
-import {
-  getDirectClient,
-  getAllDirectClients,
-  getAllClientCids
-} from '../stores/connectionStore'; // Adjust path if needed
+import { getDirectClient, getAllDirectClients, getAllClientCids } from '../stores/connectionStore'; // Adjust path if needed
 import { registerNegoHandler, registerCleanup } from '../stores/appStateStore'; // Import store functions
 import type { StreamEndNegoMessage } from '../types/negoMessages'; // Adjusted import path
 import {

--- a/src/lib/streamBridge.ts
+++ b/src/lib/streamBridge.ts
@@ -7,15 +7,15 @@ import {
   removeRemoteStream,
   updateStreamConfig,
   getLocalStreamsByType
-} from '../stores/streamStore.js';
-import { getAllConfig, configStore, type Config, type MediaConfig } from '../stores/configStore.js';
+} from '../stores/streamStore';
+import { getAllConfig, configStore, type Config, type MediaConfig } from '../stores/configStore';
 import {
   getDirectClient,
   getAllDirectClients,
   getAllClientCids
-} from '../stores/connectionStore.js'; // Adjust path if needed
-import { registerNegoHandler, registerCleanup } from '../stores/appStateStore.js'; // Import store functions
-import type { StreamEndNegoMessage } from '../types/negoMessages.js'; // Adjusted import path
+} from '../stores/connectionStore'; // Adjust path if needed
+import { registerNegoHandler, registerCleanup } from '../stores/appStateStore'; // Import store functions
+import type { StreamEndNegoMessage } from '../types/negoMessages'; // Adjusted import path
 import {
   type AudioNodes,
   normalizeStreamId,
@@ -23,10 +23,10 @@ import {
   processAudio,
   stopProcessingAudio,
   tearDownStream
-} from './media/stream.js';
+} from './media/stream';
 // Export background utilities
-import { backgroundChange } from './media/background.js';
-import { getLocalFileStreamState } from '..//stores/localFileStreamStore.js';
+import { backgroundChange } from './media/background';
+import { getLocalFileStreamState } from '..//stores/localFileStreamStore';
 
 // Module-level storage for audio processing contexts/nodes
 let audioProcessingContexts: Record<string, AudioNodes | null> = {};
@@ -464,6 +464,6 @@ export const setupLocalFileStream = (stream: MediaStream): void => {
 };
 
 // Export utility functions from the original stream.ts
-export { normalizeStreamId } from './media/stream.js';
+export { normalizeStreamId } from './media/stream';
 
 // REMOVE helper function sendNego

--- a/src/lib/webrtc/WebRTCApp.ts
+++ b/src/lib/webrtc/WebRTCApp.ts
@@ -1,10 +1,10 @@
-import { EMOJIS } from '../utils/emojis.js';
+import { EMOJIS } from '../utils/emojis';
 import {
   setCidKeys,
   removeCidKeys,
   resetCidKeyStore,
   getKeysByCid
-} from '../../stores/cidKeyStore.js';
+} from '../../stores/cidKeyStore';
 import type {
   NegoData,
   NegoMessageMap,
@@ -16,7 +16,7 @@ import type {
   ParticipantEndNegoMessage,
   HangupNegoMessage,
   BaseNegoMessage
-} from '../../types/negoMessages.js';
+} from '../../types/negoMessages';
 import {
   addDirectClient,
   updateDirectClientState,
@@ -30,26 +30,26 @@ import {
   getAllClientCids,
   type DirectClientState,
   getDirectClientState
-} from '../../stores/connectionStore.js';
-import { getAllConfig } from '../../stores/configStore.js';
-import { updatePeerProfile, removePeerProfile } from '../../stores/peerProfileStore.js';
+} from '../../stores/connectionStore';
+import { getAllConfig } from '../../stores/configStore';
+import { updatePeerProfile, removePeerProfile } from '../../stores/peerProfileStore';
 import {
   registerNegoHandler,
   getNegoHandler,
   getAllCleanups,
   resetAppStateStore
-} from '../../stores/appStateStore.js';
+} from '../../stores/appStateStore';
 import { diffChars } from 'diff';
-import { streamInit } from '../streamBridge.js';
-import { forwardInit } from '../forwardBridge.js';
+import { streamInit } from '../streamBridge';
+import { forwardInit } from '../forwardBridge';
 
-import { setupTrackHandler } from '../streamBridge.js';
-import { setupForwardChannel } from '../forwardBridge.js';
-import { setupChatChannel } from '../chatBridge.js';
-import { setupFileChannel } from '../fileBridge.js';
-import { setupTranscriptionChannel } from '../media/transcriber.js';
-import { createSolutionHandler, createChallengeHandler } from './authHandler.js';
-import { NegotiationManager, type NegotiationManagerContext } from './negotiationManager.js';
+import { setupTrackHandler } from '../streamBridge';
+import { setupForwardChannel } from '../forwardBridge';
+import { setupChatChannel } from '../chatBridge';
+import { setupFileChannel } from '../fileBridge';
+import { setupTranscriptionChannel } from '../media/transcriber';
+import { createSolutionHandler, createChallengeHandler } from './authHandler';
+import { NegotiationManager, type NegotiationManagerContext } from './negotiationManager';
 
 export class WebRTCApp {
   private sids: Record<string, string> = {};

--- a/src/lib/webrtc/authHandler.ts
+++ b/src/lib/webrtc/authHandler.ts
@@ -3,13 +3,13 @@ import type {
   ChallengeNegoMessage,
   NegoData,
   TrustedNegoMessage
-} from '../../types/negoMessages.js';
+} from '../../types/negoMessages';
 // WebRTCClient is globally available from types/global.d.ts
-import { getDirectClient } from '../../stores/connectionStore.js';
-import { setCidKeys } from '../../stores/cidKeyStore.js';
-import { updatePeerProfile } from '../../stores/peerProfileStore.js';
-import { verifyLoginJWTFromBase64, authStore } from '../../stores/authStore.js';
-import { profileStore } from '../../stores/profileStore.js';
+import { getDirectClient } from '../../stores/connectionStore';
+import { setCidKeys } from '../../stores/cidKeyStore';
+import { updatePeerProfile } from '../../stores/peerProfileStore';
+import { verifyLoginJWTFromBase64, authStore } from '../../stores/authStore';
+import { profileStore } from '../../stores/profileStore';
 import { get } from 'svelte/store';
 
 // Helper to convert Base64URL string to ArrayBuffer

--- a/src/lib/webrtc/negotiationManager.ts
+++ b/src/lib/webrtc/negotiationManager.ts
@@ -9,9 +9,9 @@ import type {
   ParticipantEndNegoMessage,
   TrustedNegoMessage,
   BaseNegoMessage
-} from '../../types/negoMessages.js';
-import type { SpecificNegoHandler } from '../../stores/appStateStore.js'; // For handler types
-import type { CidKeys } from '../../stores/cidKeyStore.js';
+} from '../../types/negoMessages';
+import type { SpecificNegoHandler } from '../../stores/appStateStore'; // For handler types
+import type { CidKeys } from '../../stores/cidKeyStore';
 
 export interface NegotiationManagerContext {
   uuidv4: () => string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { mount } from 'svelte';
 import App from './App.svelte';
-import { WebRTCApp } from './lib/webrtc/WebRTCApp.js';
-import { authStore } from './stores/authStore.js'; // Import authStore
+import { WebRTCApp } from './lib/webrtc/WebRTCApp';
+import { authStore } from './stores/authStore'; // Import authStore
 
 // Make WebRTCApp available globally
 window.WebRTCApp = WebRTCApp;

--- a/src/stores/appStateStore.test.ts
+++ b/src/stores/appStateStore.test.ts
@@ -7,8 +7,8 @@ import {
   resetAppStateStore,
   type SpecificNegoHandler,
   type CleanupFunc
-} from './appStateStore.js';
-import type { NegoMessageType, NegoMessageMap } from '../types/negoMessages.js';
+} from './appStateStore';
+import type { NegoMessageType, NegoMessageMap } from '../types/negoMessages';
 
 describe('appStateStore', () => {
   beforeEach(() => {

--- a/src/stores/appStateStore.ts
+++ b/src/stores/appStateStore.ts
@@ -1,5 +1,5 @@
 import { writable, get } from 'svelte/store';
-import type { NegoMessageMap, NegoMessageType } from '../types/negoMessages.js'; // Adjusted import path
+import type { NegoMessageMap, NegoMessageType } from '../types/negoMessages'; // Adjusted import path
 
 // Define types for handlers and cleanup functions
 export type SpecificNegoHandler<K extends NegoMessageType> = (

--- a/src/stores/cidKeyStore.test.ts
+++ b/src/stores/cidKeyStore.test.ts
@@ -8,7 +8,7 @@ import {
   cidKeyStore, // Import the store itself for direct inspection if needed
   type CidKeys,
   type CidKeyState // Added for typing the store's state
-} from './cidKeyStore.js';
+} from './cidKeyStore';
 import { get } from 'svelte/store';
 
 describe('cidKeyStore', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,9 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strictNullChecks": true,
+    "allowJs": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext", "WebWorker"],
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
This PR addresses an issue where TypeScript imports required .js extensions.

Changes made:
- Modified `tsconfig.json` to include `allowJs: true`, `allowImportingTsExtensions: true`, and `noEmit: true` in `compilerOptions`.
- Updated import statements across `.ts` and `.svelte` files in the `src` directory to remove the `.js` extension.

The project now builds successfully with these changes.