### PR TITLE
Fix: Correct mock path in ConfigOverlay.test.ts

### DIFF
--- a/src/components/ConfigOverlay.test.ts
+++ b/src/components/ConfigOverlay.test.ts
@@ -5,7 +5,7 @@ import { tick } from 'svelte';
 import ConfigOverlay from './ConfigOverlay.svelte';
 
 // Mock the configStore as it's used internally by the component
-vi.mock('../stores/configStore.ts', async () => {
+vi.mock('../lib/stores/configStore.ts', async () => {
   // Added async here
   const {
     writable: actualWritable


### PR DESCRIPTION
This PR fixes a failing test in `ConfigOverlay.test.ts`.

The test was failing because the `vi.mock` call for `configStore` used an incorrect path, causing the component to use the original store instead of the mocked one during the test. This resulted in the username input field being empty instead of displaying the mocked 'TestUser'.

The fix updates the mock path to correctly point to `../lib/stores/configStore.ts`.